### PR TITLE
Added error handler for build:scripts.

### DIFF
--- a/src/tasks/build/scripts.js
+++ b/src/tasks/build/scripts.js
@@ -57,6 +57,12 @@ gulp.task('build:scripts', ['clean:scripts'], function()
                 detectGlobals: true,
                 noParse: false
             }).bundle()
+            // adding an error handler, for when the pipe breaks
+            // According to: http://www.bennadel.com/blog/2692-you-have-to-explicitly-end-streams-after-pipes-break-in-node-js.htm
+            // the stream has to be ended, but it works without ending it
+            .on('error', function (err) {
+                console.log(err.message);
+            })
             .pipe(stream(name))
             .pipe(buffer())
             .pipe(gulpif(!global.is_production, sourcemaps.init({loadMaps: true}))) // load map from browserify file


### PR DESCRIPTION
For this commit I'm adding an error handler for the Browserify pipe. For every syntax error the pipe was breaking and stopping the ´watch´ task, requiring to initiate it again.

As read in more than one source (ie: http://www.bennadel.com/blog/2692-you-have-to-explicitly-end-streams-after-pipes-break-in-node-js.htm), the pipe has to be explicitly ended in the error handler, but it worked without including that.
