### PR TITLE
Removing Babelify and Vueifiy from version 1.1

### DIFF
--- a/src/tasks/build/scripts.js
+++ b/src/tasks/build/scripts.js
@@ -29,8 +29,6 @@
 
 var gulp       = require('gulp');
 var browserify = require('browserify');
-var babelify   = require('babelify');
-var vueify     = require('vueify');
 var gulpif     = require('gulp-if');
 var rev        = require('gulp-rev');
 var sourcemaps = require('gulp-sourcemaps');
@@ -59,8 +57,6 @@ gulp.task('build:scripts', ['clean:scripts'], function()
                 detectGlobals: true,
                 noParse: false
             })
-            .transform(vueify)
-            .transform(babelify)
             .bundle()
 
             // Adding an error handler, for when the pipe breaks


### PR DESCRIPTION
@dalabarge Not sure why but the babelify and vueify code got merged to 1.1. This was generating problems with some projects build as none of these packages were included in the package.json.
So removing them from 1.1 and leaving them on 1.2. What do you think?