### PR TITLE
Fixes regarding Babelify

### DIFF
--- a/build.json
+++ b/build.json
@@ -13,11 +13,7 @@
         ],
         "babelify": {
             "presets": [
-                "es2015",
-                "flow"
-            ],
-            "plugins": [
-                "syntax-flow"
+                "es2015"
             ]
         }
     },

--- a/src/tasks/build/scripts.js
+++ b/src/tasks/build/scripts.js
@@ -60,7 +60,7 @@ gulp.task('build:scripts', ['clean:scripts'], function()
                 noParse: false
             })
             .transform(vueify)
-            .transform(babelify)
+            .transform(babelify, { presets: config.babelify.presets })
             .bundle()
 
             // Adding an error handler, for when the pipe breaks


### PR DESCRIPTION
@dalabarge this is regarding what we were talking about today.

I saw that the babelify's presets were added to the build.json but were not used anywhere. So with this fix we will start to make use of them.

Also I removed the flowtype preset that was added by default on the build.json, as I think it is only for specific projects.